### PR TITLE
sbom-explorer: match exact sbom name

### DIFF
--- a/tests/features/@sbom-explorer/sbom-explorer.step.ts
+++ b/tests/features/@sbom-explorer/sbom-explorer.step.ts
@@ -16,7 +16,7 @@ Given(
     await page.getByPlaceholder("Search").fill(sbomName);
     await page.getByPlaceholder("Search").press("Enter");
 
-    await page.getByRole("link", { name: sbomName }).click();
+    await page.getByRole("link", { name: sbomName, exact: true }).click();
   }
 );
 


### PR DESCRIPTION
It is possible that there are additional SBOMs already uploaded in the trustify instance used for test, and their names could be similar to the one uploaded for testing, use exact matching when locating the item in search results.

Othewise test can fail due to locating multiple matching candidates.

For example for sbomName='quarkus-bom' the test fails due to matching results like:
- quarkus-bom
- quarkus-bom-2.13.8.Final-redhat-00004
- quarkus-bom-2.13.8.SP2-redhat-00001
- ... and many more like that