### PR TITLE
:sparkles: remove trustify-api-tests

### DIFF
--- a/.github/workflows/global-ci.yaml
+++ b/.github/workflows/global-ci.yaml
@@ -19,4 +19,4 @@ jobs:
       operator_bundle: "ghcr.io/trustification/trustify-operator-bundle:latest"
       run_api_tests: false
       run_ui_tests: true
-      ui_tests_ref: ${{ github.event.number && format('refs/pull/{0}/merge', github.event.number) || '' }}
+      tests_ref: ${{ github.event.number && format('refs/pull/{0}/merge', github.event.number) || '' }}

--- a/.github/workflows/global-ci.yaml
+++ b/.github/workflows/global-ci.yaml
@@ -17,6 +17,6 @@ jobs:
     uses: trustification/trustify-ci/.github/workflows/global-ci.yml@main
     with:
       operator_bundle: "ghcr.io/trustification/trustify-operator-bundle:latest"
-      run_api_tests: false
+      run_api_tests: true
       run_ui_tests: true
       tests_ref: ${{ github.event.number && format('refs/pull/{0}/merge', github.event.number) || '' }}


### PR DESCRIPTION
The Actions trustification/trustify-ci/.github/workflows/global-ci.yml@main has been modified so it expect  ui tests and api tests to be under this repository.

So this PR will align trustify-ci actions